### PR TITLE
Fix client count

### DIFF
--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -4,6 +4,7 @@ The client manager manages data in client table
 from datetime import datetime
 
 import asyncpg
+import pytz
 
 from .const import connection_url
 
@@ -27,7 +28,7 @@ class ClientManager(object):
         conn = await asyncpg.connect(connection_url())
         await conn.execute(
             'INSERT INTO client (fd, identifier, connected_on) values ($1, $2, $3)',
-            fd, identifier, datetime.now())
+            fd, identifier, datetime.utcnow().replace(tzinfo=pytz.utc))
 
     async def deactivate(self, identifier):
         conn = await asyncpg.connect(connection_url())

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -37,8 +37,8 @@ class ClientManager(object):
         conn = await asyncpg.connect(connection_url())
         await conn.execute('UPDATE client SET active = FALSE')
 
-    async def list(self):
+    async def count(self):
         'Return count of active clients'
         conn = await asyncpg.connect(connection_url())
-        res = await conn.fetch('select fd, identifier from client where active = TRUE')
-        return ['{}:{}'.format(p['fd'], p['identifier']) for p in res]
+        c = await conn.fetchval('select count(*) from client where active = TRUE')
+        return (True, c)

--- a/server/slogan_manager.py
+++ b/server/slogan_manager.py
@@ -100,5 +100,4 @@ class SloganManager(object):
         conn = await asyncpg.connect(connection_url())
         num_slogans = await conn.fetchval('select count(*) from slogan')
         num_rents = await conn.fetchval('select count(*) from slogan where rented_on is not null')
-        num_clients = await conn.fetchval('select count(*) from client')
-        return (True, (num_slogans, num_rents, num_clients))
+        return (True, (num_slogans, num_rents))

--- a/server/util.py
+++ b/server/util.py
@@ -1,0 +1,6 @@
+import random
+import string
+
+
+def random_string(length=20):
+    return ''.join(random.choice(string.ascii_lowercase) for i in range(length))  # nosec

--- a/test/test_client_manager.py
+++ b/test/test_client_manager.py
@@ -1,0 +1,24 @@
+"""
+Tests for interaction with db for slogans
+"""
+import asyncio
+from unittest import TestCase
+
+from server.client_manager import ClientManager
+from server.util import random_string
+
+
+class ClientManagerTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cm = ClientManager()
+        cls.loop = asyncio.get_event_loop()
+
+    def test_count(self):
+        async def _test_count(self):
+            await self.cm.create(1, random_string())
+            return await self.cm.count()
+        status, num_clients = self.loop.run_until_complete(_test_count(self))
+        assert status is True
+        assert num_clients > 0

--- a/test/test_slogan_manager.py
+++ b/test/test_slogan_manager.py
@@ -2,21 +2,16 @@
 Tests for interaction with db for slogans
 """
 import asyncio
-import random
-import string
 from unittest import TestCase
 
 import asyncpg
 
 from server.const import connection_url
 from server.slogan_manager import SloganManager
+from server.util import random_string
 
 
 class SloganManagerTest(TestCase):
-
-    @staticmethod
-    def random_title():
-        return ''.join(random.choice(string.ascii_lowercase) for i in range(20))  # nosec
 
     @classmethod
     def setUpClass(cls):
@@ -38,7 +33,7 @@ class SloganManagerTest(TestCase):
 
     def test_create(self):
         async def _test_create(self):
-            title = self.random_title()
+            title = random_string()
             ok, res = await self.sm.create(title)
             assert ok is True
             assert res == title
@@ -46,7 +41,7 @@ class SloganManagerTest(TestCase):
 
     def test_create_unique_constraint(self):
         async def _test_create_unique_constraint(self):
-            title = self.random_title()
+            title = random_string()
             await self.sm.create(title)
             ok, _ = await self.sm.create(title)
             assert ok is False
@@ -54,7 +49,7 @@ class SloganManagerTest(TestCase):
 
     def test_rent_when_available(self):
         async def _test_rent_when_available(self):
-            title = self.random_title()
+            title = random_string()
             await self.sm.create(title)
             status, _ = await self.sm.rent(rented_by=title)
             assert status is True
@@ -70,10 +65,10 @@ class SloganManagerTest(TestCase):
 
     def test_list(self):
         async def _test_list(self):
-            title = self.random_title()
+            title = random_string()
             await self.sm.create(title)
             return await self.sm.list()
         status, res = self.loop.run_until_complete(_test_list(self))
         assert status is True
         assert res[0] > 0
-        assert len(res) == 3
+        assert len(res) == 2


### PR DESCRIPTION
The client count in status should show only the connected (active) client count. So move this responsibility to client_manager. Also add a test to check this behaviour.